### PR TITLE
Finance FAQ markdown tweaks

### DIFF
--- a/finance_faq.md
+++ b/finance_faq.md
@@ -64,12 +64,12 @@ Enter your current password and choose and answer each of the three question pro
 ## NetSuite and Zuora<a id="netsuitezuora"></a>
 
 ### How do I make changes to a payment in NetSuite and resync to Zuora?<a id="nszuresyncpmt"></a>
-1. Request a Transaction unlock on the payment by hitting the "Request Unlock" button in NetSuite. Wait for a response from the NetSuite Admin before proceding to step 2 below.
-2.	Find the equivalent payment in Zuora for this payment. Should be pretty easy to find, but you can find additional information in the “Zuora Sync Details” tab, specifically the Zuora ID, which can be used in Zuora’s URL to go straight to the payment.
- * a.	https://www.zuora.com/apps/NewPayment.do?method=view&id=<em>zuoraidhere</em> 
- * EG: https://www.zuora.com/apps/NewPayment.do?method=view&id=2c92a0ff528dec7f01529e8952f95044
-3.	Edit the payment in Zuora, set the “Transferred to Accounting” field to “Ignore”. Save
+1. Request a Transaction unlock on the payment by hitting the `Request Unlock` button in NetSuite. Wait for a response from the NetSuite Admin before proceding to step 2 below.
+2.	Find the equivalent payment in Zuora for this payment. Should be pretty easy to find, but you can find additional information in the `Zuora Sync Details` tab, specifically the Zuora ID, which can be used in Zuora’s URL to go straight to the payment.
+ * a.	`https://www.zuora.com/apps/NewPayment.do?method=view&id=`*`[zuora id here]`*
+ * EG: `https://www.zuora.com/apps/NewPayment.do?method=view&id=2c92a0ff528dec7f01529e8952f95044`
+3.	Edit the payment in Zuora, set the `Transferred to Accounting` field to `Ignore`. Save
 4.	Cancel the payment in Zuora.
 5.	Let the NetSuite Admin know once the Zuora Payment is cancelled, They will then unlock the payment in NetSuite for editing.
-6.	When it is unlocked in NetSuite, you will need to first clear out two fields of data in the “Zuora Sync Details” tab, clear out the “ZUORA ID” field and the “ZUORA INTEGRATION STATUS” field, make them both blank. This will let Zuora know this payment needs to be resynced. <strong>Do not save yet.</strong> Now go ahead and make the appropriate edits needed, then save. After you save, the transaction will automatically relock and Zuora will know to attempt resyncing the payment from NetSuite to Zuora.
+6.	When it is unlocked in NetSuite, you will need to first clear out two fields of data in the `Zuora Sync Details` tab, clear out the `ZUORA ID` field and the `ZUORA INTEGRATION STATUS` field, make them both blank. This will let Zuora know this payment needs to be resynced. **Do not save yet.** Now go ahead and make the appropriate edits needed, then save. After you save, the transaction will automatically relock and Zuora will know to attempt resyncing the payment from NetSuite to Zuora.
 


### PR DESCRIPTION
- Markdown formatting is better than HTML formatting
  - `*foo*` is the Markdown equivalent to `<em>foo</em>`
  - `**foo**` is the Markdown equivalent to `<strong>foo</strong>`
- quotes are fine, but backticks will add some extra `formatting` that's nice to have around technical terms, section names, etc. IMHO
